### PR TITLE
Fix the Mods button spacing

### DIFF
--- a/src/main/java/com/mosadie/islandmenu/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/mosadie/islandmenu/mixin/TitleScreenMixin.java
@@ -104,7 +104,7 @@ public abstract class TitleScreenMixin extends Screen {
         ButtonWidget.Builder modsButtonWidgetBuilder = ButtonWidget.builder(ModMenu.createModsButtonText(true), button -> {
             Screen modsScreen = ModMenuApi.createModsScreen(MinecraftClient.getInstance().currentScreen);
             MinecraftClient.getInstance().setScreen(modsScreen);
-        }).position(self.width / 2 + 110, y + spacingY).size(50, 20);
+        }).position(self.width / 2 + 104, y + spacingY).size(50, 20);
 
         ButtonWidget modsButtonWidget = modsButtonWidgetBuilder.build();
 


### PR DESCRIPTION
It was bothering me that it was farther from the middle then the other buttons. (Especially noticeable when Replay Mod was installed)