### PR TITLE
Update Release Action

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -24,7 +24,7 @@ jobs:
       run: './gradlew build --no-daemon'
     
     - name: Publish
-      uses: Kir-Antipov/mc-publish@v3.2
+      uses: Kir-Antipov/mc-publish@v3.3
       with:
         version-type: release
 


### PR DESCRIPTION
Update Kir-Antipov/mc-publish to fix the Node 12 warning.